### PR TITLE
Store casino balance locally

### DIFF
--- a/games/casino/assets/css/craps.css
+++ b/games/casino/assets/css/craps.css
@@ -17,3 +17,4 @@
 .bet-controls {
   margin: 10px 0;
 }
+.craps-rules { margin-bottom: 10px; font-style: italic; }

--- a/games/casino/assets/css/lobby.css
+++ b/games/casino/assets/css/lobby.css
@@ -1,0 +1,6 @@
+/* Styles for Casino Lobby */
+#casino-lobby .container {
+  text-align: center;
+  padding-top: 30px;
+  padding-bottom: 30px;
+}

--- a/games/casino/assets/js/cards.js
+++ b/games/casino/assets/js/cards.js
@@ -17,10 +17,11 @@ document.addEventListener('DOMContentLoaded', () => {
     let dealerHand = [];
     let playerScore = 0;
     let dealerScore = 0;
-    let balance = 100; // Starting balance
+    let balance = loadCasinoBalance();
     let playerBet = 10; // Example fixed bet - you might want an input for this
     let gameInProgress = false;
     let dealerHiddenCard = null; // To store the dealer's face-down card
+
 
     // --- Constants ---
     const suits = ['Hearts', 'Diamonds', 'Clubs', 'Spades'];
@@ -29,6 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Initialization ---
     function initializeCardGame() {
         updateBalanceDisplay();
+        saveCasinoBalance(balance);
         setupButtonListeners();
         resetUI();
         console.log("Card game initialized (Blackjack structure).");
@@ -182,6 +184,7 @@ document.addEventListener('DOMContentLoaded', () => {
             gameStatusDiv.textContent = "Blackjack! You win!";
             balance += playerBet * 2.5; // Blackjack typically pays 3:2
              updateBalanceDisplay();
+            saveCasinoBalance(balance);
             endRound();
         }
     }
@@ -233,8 +236,9 @@ document.addEventListener('DOMContentLoaded', () => {
                  clearInterval(dealerTurn);
                  gameStatusDiv.textContent = `Dealer busts! Dealer score: ${dealerScore}. You win $${playerBet}!`;
                  balance += playerBet * 2; // Win original bet + winnings
-                 updateBalanceDisplay();
-                 endRound();
+                updateBalanceDisplay();
+                saveCasinoBalance(balance);
+                endRound();
              }
         }, 1000); // Delay between dealer hits for visibility
     }
@@ -264,6 +268,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         gameStatusDiv.textContent = finalMessage;
         updateBalanceDisplay();
+        saveCasinoBalance(balance);
     }
 
 

--- a/games/casino/assets/js/craps.js
+++ b/games/casino/assets/js/craps.js
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const balanceSpan = document.getElementById('balance-amount');
   const betInput = document.getElementById('bet-amount');
 
-  let balance = 100;
+  let balance = loadCasinoBalance();
   let point = null;
 
   function updateBalance() {
@@ -43,6 +43,7 @@ document.addEventListener('DOMContentLoaded', () => {
         point = sum;
         messageDiv.textContent = `Point is ${point}. Roll again.`;
         updateBalance();
+        saveCasinoBalance(balance);
         return;
       }
     } else {
@@ -57,11 +58,13 @@ document.addEventListener('DOMContentLoaded', () => {
       } else {
         messageDiv.textContent = `You rolled ${sum}. Roll again for ${point}.`;
         updateBalance();
+        saveCasinoBalance(balance);
         return;
       }
     }
 
     updateBalance();
+    saveCasinoBalance(balance);
   }
 
   rollButton.addEventListener('click', playRound);

--- a/games/casino/assets/js/slots.js
+++ b/games/casino/assets/js/slots.js
@@ -18,6 +18,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const stopButtons = [];
     for (let i = 0; i < 5; i++) { stopButtons.push(document.getElementById(`stop-reel-${i}`)); }
 
+    // Persist balance locally so players can come back later
+
     const ROWS = 3; const COLS = 5;
     const IMAGE_BASE_PATH = 'assets/images/'; // Base path for casino game images
 
@@ -94,7 +96,7 @@ document.addEventListener('DOMContentLoaded', () => {
         [2, 1, 1, 1, 2], [1, 0, 1, 2, 1], [1, 2, 1, 0, 1], [0, 1, 0, 1, 0], [2, 1, 2, 1, 2]
     ];
 
-    let balance = 100;
+    let balance = loadCasinoBalance();
     let currentBetLevelIndex = 0;
     let currentCoinValueIndex = 2;
     let isSpinning = false;
@@ -252,6 +254,7 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             balance -= currentCost;
             updateBalanceDisplay();
+            saveCasinoBalance(balance);
             resultMessage.textContent = 'Starting Spin...';
         }
 
@@ -544,6 +547,7 @@ document.addEventListener('DOMContentLoaded', () => {
             resultMessage.textContent = freeSpinsRemaining > 0 && !bonusTriggeredThisSpin ? `Free Spin! ${freeSpinsRemaining} left.` : (bonusTriggeredThisSpin ? resultMessage.textContent : `Try Again!`);
         }
         updateBalanceDisplay();
+        saveCasinoBalance(balance);
 
         if (freeSpinsRemaining > 0 && !bonusTriggeredThisSpin) {
             // console.log(`Scheduling next free spin. Remaining: ${freeSpinsRemaining}`);

--- a/games/casino/assets/js/storage.js
+++ b/games/casino/assets/js/storage.js
@@ -1,0 +1,17 @@
+(function(global){
+  function loadCasinoBalance(){
+    const saved = global.localStorage.getItem('casinoBalance');
+    return saved ? parseFloat(saved) : 100;
+  }
+
+  function saveCasinoBalance(balance){
+    global.localStorage.setItem('casinoBalance', String(balance));
+  }
+
+  global.loadCasinoBalance = loadCasinoBalance;
+  global.saveCasinoBalance = saveCasinoBalance;
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { loadCasinoBalance, saveCasinoBalance };
+  }
+})(typeof window !== 'undefined' ? window : global);

--- a/games/casino/cards.html
+++ b/games/casino/cards.html
@@ -69,6 +69,7 @@
         </div>
     </footer>
 
+    <script src="assets/js/storage.js"></script>
     <script src="assets/js/cards.js"></script>
      <script>
         if (typeof initializeCardGame === 'undefined' && document.getElementById('game-status')) {

--- a/games/casino/craps.html
+++ b/games/casino/craps.html
@@ -28,6 +28,7 @@
     <main id="craps-container">
         <div class="container">
             <h2>Roll the Dice!</h2>
+            <p class="craps-rules">7 or 11 on the first roll wins. 2, 3, or 12 loses. Any other number becomes your point &mdash; roll it again before a 7 to win.</p>
             <div class="bet-controls">
                 <label>Bet: $<input id="bet-amount" type="number" value="10" min="1"></label>
                 <button id="roll-button" class="btn casino-btn">Roll</button>
@@ -46,6 +47,7 @@
         </div>
     </footer>
 
+    <script src="assets/js/storage.js"></script>
     <script src="assets/js/craps.js"></script>
 </body>
 </html>

--- a/games/casino/index.html
+++ b/games/casino/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Casino Lobby</title>
+    <script>
+        function applyGameTheme(themeName){
+            const validTheme = (themeName==='dark-mode'||themeName==='light-mode')?themeName:'light-mode';
+            document.documentElement.className = validTheme;
+        }
+        try{const savedTheme=localStorage.getItem('theme');applyGameTheme(savedTheme);}catch(e){applyGameTheme('light-mode');}
+    </script>
+    <link rel="stylesheet" href="../../assets/css/style.css">
+    <link rel="stylesheet" href="assets/css/lobby.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="icon" href="../../assets/images/favicon.png" type="image/png">
+</head>
+<body>
+    <header class="game-header">
+        <div class="container">
+            <a href="../../index.html#casino" class="btn back-btn">← Back</a>
+            <h1><i class="fas fa-crown" aria-hidden="true"></i> Casino Lobby</h1>
+            <div class="header-spacer" aria-hidden="true"></div>
+        </div>
+    </header>
+    <main id="casino-lobby">
+        <div class="container">
+            <h2>Select a Game</h2>
+            <div class="casino-games">
+                <a href="slots.html" class="btn casino-btn"><i class="fas fa-dice-three"></i> Slots</a>
+                <a href="cards.html" class="btn casino-btn"><i class="fas fa-heart"></i> Blackjack</a>
+                <a href="craps.html" class="btn casino-btn"><i class="fas fa-dice"></i> Craps</a>
+            </div>
+        </div>
+    </main>
+    <footer class="game-footer">
+        <div class="container">
+            <p>© 2024 Gavin - Casino Lobby</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/games/casino/slots.html
+++ b/games/casino/slots.html
@@ -119,6 +119,7 @@
         </div>
     </footer>
 
+    <script src="assets/js/storage.js"></script>
     <script src="assets/js/slots.js"></script>
     <script>
         if (typeof initializeSlots === 'undefined' && document.getElementById('result-message')) {

--- a/index.html
+++ b/index.html
@@ -189,14 +189,8 @@
             <h2>Casino Corner</h2>
             <p>Feeling lucky? Try your hand at some simple casino-style mini-games I've created.</p>
             <div class="casino-games">
-                <a href="games/casino/slots.html" class="btn casino-btn">
-                    <i class="fas fa-dice-three"></i> Play Slots
-                </a>
-                <a href="games/casino/cards.html" class="btn casino-btn">
-                    <i class="fas fa-heart"></i> Play Cards
-                </a>
-                <a href="games/casino/craps.html" class="btn casino-btn">
-                    <i class="fas fa-dice"></i> Play Craps
+                <a href="games/casino/index.html" class="btn casino-btn">
+                    <i class="fas fa-crown"></i> Enter Casino
                 </a>
             </div>
         </div>

--- a/package.json
+++ b/package.json
@@ -2,5 +2,8 @@
   "dependencies": {
     "express": "^4.21.1",
     "socket.io": "^4.7.5"
+  },
+  "scripts": {
+    "test": "node test/testLocalBalance.js"
   }
 }

--- a/test/testLocalBalance.js
+++ b/test/testLocalBalance.js
@@ -1,0 +1,31 @@
+const { loadCasinoBalance, saveCasinoBalance } = require('../games/casino/assets/js/storage.js');
+
+global.localStorage = {
+  _data: {},
+  getItem(key) {
+    return Object.prototype.hasOwnProperty.call(this._data, key) ? this._data[key] : null;
+  },
+  setItem(key, value) {
+    this._data[key] = String(value);
+  },
+  removeItem(key) {
+    delete this._data[key];
+  },
+  clear() {
+    this._data = {};
+  }
+};
+
+let balance = loadCasinoBalance();
+if (balance !== 100) {
+  throw new Error(`Expected default balance 100, got ${balance}`);
+}
+
+saveCasinoBalance(250);
+
+balance = loadCasinoBalance();
+if (balance !== 250) {
+  throw new Error(`Expected saved balance 250, got ${balance}`);
+}
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- remove casino-server and persistent JSON
- persist casino balance in `localStorage` for craps and slots
- add dedicated casino lobby and persistent balance for blackjack
- explain basic craps rules and link from portfolio
- add shared storage helper and unit test

## Testing
- `npm test`