### PR TITLE
Add additional casino games and update navigation

### DIFF
--- a/games/casino/assets/css/poker.css
+++ b/games/casino/assets/css/poker.css
@@ -1,0 +1,10 @@
+#poker-container .container {
+  text-align: center;
+  padding-top: 30px;
+  padding-bottom: 30px;
+}
+
+#poker-message {
+  margin: 20px 0;
+  font-style: italic;
+}

--- a/games/casino/assets/css/slots-classic.css
+++ b/games/casino/assets/css/slots-classic.css
@@ -1,0 +1,43 @@
+#classic-slot-container .container {
+  text-align: center;
+  padding-top: 30px;
+  padding-bottom: 30px;
+}
+
+#classic-slot-machine {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  gap: 5px;
+  width: 300px;
+  height: 300px;
+  margin: 0 auto 15px auto;
+  background-color: #555;
+  border: 5px solid #333;
+  border-radius: 10px;
+  padding: 10px;
+  box-sizing: border-box;
+}
+html.dark-mode #classic-slot-machine {
+  background-color: #3a3a3a;
+  border-color: #111;
+}
+
+.classic-cell {
+  background: #fff;
+  border: 1px solid #999;
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2em;
+}
+html.dark-mode .classic-cell {
+  background: #ddd;
+  border-color: #aaa;
+}
+
+.classic-win {
+  background: #fff7d6;
+  border-color: #f39c12;
+}

--- a/games/casino/assets/js/poker.js
+++ b/games/casino/assets/js/poker.js
@@ -1,0 +1,5 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const balanceSpan = document.getElementById('balance-amount');
+  let balance = loadCasinoBalance();
+  if (balanceSpan) balanceSpan.textContent = balance.toFixed(2);
+});

--- a/games/casino/assets/js/slots-classic.js
+++ b/games/casino/assets/js/slots-classic.js
@@ -1,0 +1,51 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const cells = Array.from(document.querySelectorAll('.classic-cell'));
+  const resultDiv = document.getElementById('classic-result');
+  const balanceSpan = document.getElementById('balance-amount');
+  const spinButton = document.getElementById('classic-spin-button');
+  let balance = loadCasinoBalance();
+  updateBalance();
+
+  const symbols = ['🍒','🔔','🍋','7️⃣','💎'];
+  const lines = [
+    [0,1,2],[3,4,5],[6,7,8],
+    [0,3,6],[1,4,7],[2,5,8],
+    [0,4,8],[2,4,6]
+  ];
+
+  spinButton.addEventListener('click', () => {
+    const bet = 1;
+    if (balance < bet) {
+      resultDiv.textContent = 'Not enough balance.';
+      return;
+    }
+    balance -= bet;
+    const results = [];
+    cells.forEach(cell => {
+      cell.classList.remove('classic-win');
+      const sym = symbols[Math.floor(Math.random()*symbols.length)];
+      cell.textContent = sym;
+      results.push(sym);
+    });
+    let win = false;
+    lines.forEach(line => {
+      if (results[line[0]] === results[line[1]] && results[line[1]] === results[line[2]]) {
+        win = true;
+        line.forEach(i => cells[i].classList.add('classic-win'));
+      }
+    });
+    if (win) {
+      const prize = bet * 10;
+      balance += prize;
+      resultDiv.textContent = `You won $${prize}!`;
+    } else {
+      resultDiv.textContent = 'Try again!';
+    }
+    updateBalance();
+    saveCasinoBalance(balance);
+  });
+
+  function updateBalance() {
+    balanceSpan.textContent = balance.toFixed(2);
+  }
+});

--- a/games/casino/cards.html
+++ b/games/casino/cards.html
@@ -22,7 +22,7 @@
 <body>
     <header class="game-header">
         <div class="container">
-             <a href="../../index.html#casino" class="btn back-btn" aria-label="Back to portfolio casino section">← Back</a>
+             <a href="index.html" class="btn back-btn" aria-label="Back to casino lobby">← Back</a>
              <h1><i class="fas fa-heart" aria-hidden="true"></i> Blackjack</h1>
              <div class="header-spacer" aria-hidden="true"></div>
         </div>

--- a/games/casino/craps.html
+++ b/games/casino/craps.html
@@ -19,7 +19,7 @@
 <body>
     <header class="game-header">
         <div class="container">
-            <a href="../../index.html#casino" class="btn back-btn">← Back</a>
+            <a href="index.html" class="btn back-btn">← Back</a>
             <h1><i class="fas fa-dice" aria-hidden="true"></i> Simple Craps</h1>
             <div class="header-spacer" aria-hidden="true"></div>
         </div>

--- a/games/casino/index.html
+++ b/games/casino/index.html
@@ -32,6 +32,10 @@
                     <i class="fas fa-dice-three fa-3x"></i>
                     <h3>Slots</h3>
                 </a>
+                <a href="slots-classic.html" class="casino-card">
+                    <i class="fas fa-dice fa-3x"></i>
+                    <h3>Classic Slots</h3>
+                </a>
                 <a href="cards.html" class="casino-card">
                     <i class="fas fa-heart fa-3x"></i>
                     <h3>Blackjack</h3>
@@ -43,6 +47,10 @@
                 <a href="roulette.html" class="casino-card">
                     <i class="fas fa-sync fa-3x"></i>
                     <h3>Roulette</h3>
+                </a>
+                <a href="poker.html" class="casino-card">
+                    <i class="fas fa-clone fa-3x"></i>
+                    <h3>Video Poker</h3>
                 </a>
             </div>
         </div>

--- a/games/casino/poker.html
+++ b/games/casino/poker.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Video Poker</title>
+    <script>
+        function applyGameTheme(themeName){
+            const validTheme=(themeName==='dark-mode'||themeName==='light-mode')?themeName:'light-mode';
+            document.documentElement.className=validTheme;
+        }
+        try{const savedTheme=localStorage.getItem('theme');applyGameTheme(savedTheme);}catch(e){applyGameTheme('light-mode');}
+    </script>
+    <link rel="stylesheet" href="../../assets/css/style.css">
+    <link rel="stylesheet" href="assets/css/poker.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="icon" href="../../assets/images/favicon.png" type="image/png">
+</head>
+<body>
+    <header class="game-header">
+        <div class="container">
+            <a href="index.html" class="btn back-btn">← Back</a>
+            <h1><i class="fas fa-clone" aria-hidden="true"></i> Video Poker</h1>
+            <div class="header-spacer" aria-hidden="true"></div>
+        </div>
+    </header>
+    <main id="poker-container">
+        <div class="container">
+            <h2>Coming Soon</h2>
+            <p id="poker-message">Video Poker is under construction.</p>
+            <div id="balance-display" class="game-balance" aria-live="polite">
+                Balance: $<span id="balance-amount">100</span>
+            </div>
+        </div>
+    </main>
+    <footer class="game-footer">
+        <div class="container">
+            <p>© 2024 Gavin - Video Poker</p>
+        </div>
+    </footer>
+    <script src="assets/js/storage.js"></script>
+    <script src="assets/js/poker.js"></script>
+</body>
+</html>

--- a/games/casino/roulette.html
+++ b/games/casino/roulette.html
@@ -19,7 +19,7 @@
 <body>
     <header class="game-header">
         <div class="container">
-            <a href="../../index.html#casino" class="btn back-btn">← Back</a>
+            <a href="index.html" class="btn back-btn">← Back</a>
             <h1><i class="fas fa-sync" aria-hidden="true"></i> Roulette</h1>
             <div class="header-spacer" aria-hidden="true"></div>
         </div>

--- a/games/casino/slots-classic.html
+++ b/games/casino/slots-classic.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Classic Slots</title>
+    <script>
+        function applyGameTheme(themeName){
+            const validTheme=(themeName==='dark-mode'||themeName==='light-mode')?themeName:'light-mode';
+            document.documentElement.className=validTheme;
+        }
+        try{const savedTheme=localStorage.getItem('theme');applyGameTheme(savedTheme);}catch(e){applyGameTheme('light-mode');}
+    </script>
+    <link rel="stylesheet" href="../../assets/css/style.css">
+    <link rel="stylesheet" href="assets/css/slots-classic.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="icon" href="../../assets/images/favicon.png" type="image/png">
+</head>
+<body>
+    <header class="game-header">
+        <div class="container">
+            <a href="index.html" class="btn back-btn">← Back</a>
+            <h1><i class="fas fa-dice" aria-hidden="true"></i> Classic Slots</h1>
+            <div class="header-spacer" aria-hidden="true"></div>
+        </div>
+    </header>
+    <main id="classic-slot-container">
+        <div class="container">
+            <h2>Spin the Reels!</h2>
+            <div id="classic-slot-machine" aria-label="Classic slot machine">
+                <div class="classic-cell" id="cell0"></div>
+                <div class="classic-cell" id="cell1"></div>
+                <div class="classic-cell" id="cell2"></div>
+                <div class="classic-cell" id="cell3"></div>
+                <div class="classic-cell" id="cell4"></div>
+                <div class="classic-cell" id="cell5"></div>
+                <div class="classic-cell" id="cell6"></div>
+                <div class="classic-cell" id="cell7"></div>
+                <div class="classic-cell" id="cell8"></div>
+            </div>
+            <button id="classic-spin-button" class="btn casino-btn">Spin ($1)</button>
+            <div id="classic-result" class="game-status-message"></div>
+            <div id="balance-display" class="game-balance" aria-live="polite">
+                Balance: $<span id="balance-amount">100</span>
+            </div>
+        </div>
+    </main>
+    <footer class="game-footer">
+        <div class="container">
+            <p>© 2024 Gavin - Classic Slots</p>
+        </div>
+    </footer>
+    <script src="assets/js/storage.js"></script>
+    <script src="assets/js/slots-classic.js"></script>
+</body>
+</html>

--- a/games/casino/slots.html
+++ b/games/casino/slots.html
@@ -17,7 +17,7 @@
 <body>
     <header class="game-header">
         <div class="container">
-            <a href="../../index.html#casino" class="btn back-btn" aria-label="Back to portfolio casino section">← Back</a>
+            <a href="index.html" class="btn back-btn" aria-label="Back to casino lobby">← Back</a>
             <h1><i class="fas fa-dice-d20" aria-hidden="true"></i> RPG Slot Adventure</h1>
             <div class="header-spacer" aria-hidden="true"></div>
         </div>


### PR DESCRIPTION
## Summary
- expand casino lobby with Classic Slots and Video Poker entries
- create new Classic Slots game with simple slot machine
- add placeholder Video Poker page
- update back buttons to return to the lobby

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d3b947520832fb9df44631132beb8