### PR TITLE
Improve index header and wiki layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -4,7 +4,7 @@
 body {
     margin: 0;
     padding: 0;
-    padding-top: 80px; /* Default padding for fixed header */
+    padding-top: 60px; /* Space for fixed header */
     font-family: 'Roboto', sans-serif;
     background-color: #f5f5f5;
     color: #333;
@@ -51,8 +51,17 @@ html.dark-mode body {
 
 /* Header (Main Portfolio) */
 header {
-
-  
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 1000;
+    background-color: rgba(255, 255, 255, 0.95);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    backdrop-filter: saturate(180%) blur(10px);
+}
+html.dark-mode header {
+    background-color: rgba(26, 26, 26, 0.95);
 }
 header .container {
     display: flex;
@@ -295,7 +304,10 @@ html.dark-mode .project-card:hover { box-shadow: 0 6px 12px rgba(0,0,0,0.5); }
 /* Wiki Section */
 #wiki { padding: 60px 0; }
 #wiki h2 { margin-bottom: 20px; font-size: 2em; }
+#wiki .container { display: flex; flex-wrap: wrap; gap: 20px; }
 #wiki-navigation {
+    flex: 1 1 200px;
+    max-width: 200px;
     margin-bottom: 20px;
 }
 #wiki-navigation ul {
@@ -323,11 +335,26 @@ html.dark-mode #wiki-navigation a {
 html.dark-mode #wiki-navigation a.active {
     color: #e67e22;
 }
-#wiki-search { display: block; width: 90%; max-width: 400px; padding: 10px; border: 1px solid #ccc; border-radius: 5px; font-size: 1em; margin: 0 auto 30px auto; background-color: #fff; color: #333; }
+#wiki-search {
+    display: block;
+    flex-basis: 100%;
+    width: 90%;
+    max-width: 400px;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    font-size: 1em;
+    margin: 0 auto 30px auto;
+    background-color: #fff;
+    color: #333;
+}
 html.dark-mode #wiki-search { background-color: #333; color: #ccc; border-color: #555; }
 #wiki-search:focus { border-color: #f39c12; outline: none; }
 html.dark-mode #wiki-search:focus { border-color: #e67e22; }
-#wiki-content { margin-top: 30px; }
+#wiki-content {
+    flex: 3 1 600px;
+    margin-top: 30px;
+}
 html.dark-mode #wiki-content h1, html.dark-mode #wiki-content h2, html.dark-mode #wiki-content h3 { color: #e67e22; }
 #wiki-content h1, #wiki-content h2, #wiki-content h3 { margin-top: 1.2em; margin-bottom: 0.6em; color: #f39c12; }
 #wiki-content p { margin-bottom: 1em; }
@@ -520,6 +547,10 @@ html.dark-mode .game-footer {
     #hero { padding: 100px 20px 60px; }
     #hero h2 { font-size: 2em; }
     #hero p { font-size: 1.1em; }
+
+    /* Wiki layout on mobile */
+    #wiki .container { flex-direction: column; }
+    #wiki-navigation { max-width: none; }
 
 } /* End @media (max-width: 768px) */
 


### PR DESCRIPTION
## Summary
- make site header sticky so navigation stays visible
- reduce body padding to remove top gap
- style wiki section with side navigation and better layout
- adjust wiki layout for mobile screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d954699e8832f91c12807cbbc18f4