### PR TITLE
Fix hero text color for light mode

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -228,7 +228,7 @@ html.dark-mode .btn.disabled, html.dark-mode .btn:disabled {
 /* Hero Section */
 #hero {
     background: transparent;
-    color: #fff;
+    color: #333;
     text-align: center;
     padding: 40px 20px 40px;
     position: relative;


### PR DESCRIPTION
## Summary
- ensure hero section text is dark in light mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684df50ee9d8832f9a6d9ee2e0f1c440