### PR TITLE
Only show loading overlay while images load

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -172,14 +172,25 @@ function updateParticles() {
 
 
 // Loading overlay for first visit
-function showLoadingOverlay() {
+function showLoadingOverlayIfNeeded() {
     const overlay = document.getElementById('loading-overlay');
     if (!overlay) return;
 
+    const images = Array.from(document.images);
+    const imagesPending = images.some(img => !img.complete);
+
+    if (!imagesPending) {
+        overlay.remove();
+        return;
+    }
+
     overlay.style.display = 'flex';
-    setTimeout(() => {
+
+    const hideOverlay = () => {
         overlay.classList.add('fade-out');
-    }, 1500);
+    };
+
+    window.addEventListener('load', hideOverlay);
     overlay.addEventListener('transitionend', () => overlay.remove());
 }
 
@@ -361,7 +372,7 @@ function initializeSmoothScroll() {
 document.addEventListener('DOMContentLoaded', () => {
     console.log("DOM fully loaded and parsed");
     loadTheme(); // Load theme and update UI elements like icon
-    showLoadingOverlay();
+    showLoadingOverlayIfNeeded();
 
     // Initialize other components
     initializeHamburgerMenu();


### PR DESCRIPTION
## Summary
- update loading overlay logic to wait for resource load
- only show the overlay when there are pending images

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ed197c3fc832fa5d83ee70eb950b7