### PR TITLE
Fix contact form field heights

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -316,6 +316,9 @@ html.dark-mode .project-card:hover { box-shadow: 0 6px 12px rgba(0,0,0,0.5); }
     color: #333;
     width: 100%;
 }
+#message {
+    min-height: 150px;
+}
 html.dark-mode .form-group input, html.dark-mode .form-group textarea { background-color: #333; color: #ccc; border-color: #555; }
 .form-group input:focus, .form-group textarea:focus { border-color: #f39c12; outline: none; }
 html.dark-mode .form-group input:focus, html.dark-mode .form-group textarea:focus { border-color: #e67e22; }

--- a/index.html
+++ b/index.html
@@ -190,8 +190,8 @@
                     <input type="text" id="name" name="name" required placeholder="Your Name">
                 </div>
                 <div class="form-group">
-                    <label for="contact">Preferred Response Method</label>
-                    <input type="text" id="contact" name="contact" required placeholder="Email, Discord, phone...">
+                    <label for="contactMethod">Preferred Response Method</label>
+                    <input type="text" id="contactMethod" name="contact" required placeholder="Email, Discord, phone...">
                 </div>
                 <div class="form-group">
                     <label for="message">Message</label>


### PR DESCRIPTION
## Summary
- fix overly tall contact method input by giving it a unique id
- make message textarea taller

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ed7084b34832f9ad44618e0126b91