### PR TITLE
Add custom contact form modal popup

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -330,6 +330,31 @@ html.dark-mode .social-links a { color: #aaa; }
 html.dark-mode .social-links a:hover { color: #e67e22; }
 #contactStatus { text-align: center; margin-top: 10px; }
 
+/* Contact form modal */
+.modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+.modal.show { display: flex; }
+.modal-content {
+    background: #fff;
+    padding: 20px;
+    border-radius: 5px;
+    text-align: center;
+}
+html.dark-mode .modal-content {
+    background: #333;
+    color: #fff;
+}
+
 /* Footer */
 footer { background: #333; color: #fff; padding: 20px 0; text-align: center; margin-top: 40px; }
 html.dark-mode footer { background: #111; }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -392,7 +392,24 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const contactForm = document.getElementById('contactForm');
-    if (contactForm && contactForm.getAttribute('action') === '/api/contact') {
+    const modal = document.getElementById('contactModal');
+    const modalClose = document.getElementById('contactModalClose');
+
+    function showContactModal(message) {
+        if (modal) {
+            const msgEl = document.getElementById('contactModalMessage');
+            if (msgEl) msgEl.textContent = message;
+            modal.classList.add('show');
+            setTimeout(() => modal.classList.remove('show'), 3000);
+        }
+    }
+    if (modalClose) {
+        modalClose.addEventListener('click', () => {
+            modal.classList.remove('show');
+        });
+    }
+
+    if (contactForm) {
         contactForm.addEventListener('submit', async (e) => {
             e.preventDefault();
             const formData = new FormData(contactForm);
@@ -403,19 +420,25 @@ document.addEventListener('DOMContentLoaded', () => {
             };
             const statusEl = document.getElementById('contactStatus');
             try {
-                const res = await fetch('/api/contact', {
+                const res = await fetch(contactForm.action, {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Accept': 'application/json'
+                    },
                     body: JSON.stringify(data)
                 });
                 if (res.ok) {
                     contactForm.reset();
                     if (statusEl) statusEl.textContent = 'Message sent!';
+                    showContactModal('Message sent!');
                 } else {
                     if (statusEl) statusEl.textContent = 'Error sending message';
+                    showContactModal('Error sending message');
                 }
             } catch (err) {
                 if (statusEl) statusEl.textContent = 'Error sending message';
+                showContactModal('Error sending message');
             }
         });
     }

--- a/index.html
+++ b/index.html
@@ -200,6 +200,12 @@
                 <button type="submit" class="btn">Send Message</button>
                 <p id="contactStatus" role="status"></p>
             </form>
+            <div id="contactModal" class="modal" aria-hidden="true" role="dialog">
+                <div class="modal-content">
+                    <p id="contactModalMessage">Message sent!</p>
+                    <button id="contactModalClose" class="btn" type="button">Close</button>
+                </div>
+            </div>
             <div class="social-links">
                 <a href="https://github.com/GodfreyDev" target="_blank" rel="noopener noreferrer" aria-label="GitHub"><i class="fab fa-github"></i></a>
                 <a href="https://linkedin.com/in/YOUR_LINKEDIN_ID_HERE" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>


### PR DESCRIPTION
## Summary
- add modal markup in contact section for custom popup confirmation
- style new modal in CSS
- intercept form submissions via JS and show/hide modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684efc3cb9fc832f8cb3d52db9085ac3